### PR TITLE
refactor: add dns to core infrastructure

### DIFF
--- a/deploy/aws/stacks-eks/example/main.tf
+++ b/deploy/aws/stacks-eks/example/main.tf
@@ -16,6 +16,11 @@ module "amido_stacks_infra" {
   cluster_endpoint_public_access  = var.cluster_endpoint_public_access
   cluster_endpoint_private_access = var.cluster_endpoint_private_access
 
+  # Route-53 Zone Configuration
+  enable_zone =  var.enable_zone
+  public_zones = var.public_zones 
+
+
   # Provides EKS API Access to Additional IAM Users and Roles, default Admin access is provided only to the cluster creator identity
   map_roles = var.map_roles
   map_users = var.map_users

--- a/deploy/aws/stacks-eks/example/outputs.tf
+++ b/deploy/aws/stacks-eks/example/outputs.tf
@@ -49,3 +49,21 @@ output "cluster_certificate_authority_data" {
   description = "base64 encoded certificate data required to communicate with your cluster"
   value       = module.amido_stacks_infra.cluster_certificate_authority_data
 }
+
+################
+# Route 53 Zones
+################
+output "route53_zone_zone_id" {
+  description = "Zone ID of Route53 zone"
+  value       = var.enable_zone ? module.amido_stacks_infra.route53_zone_zone_id : null
+}
+
+output "route53_zone_name_servers" {
+  description = "Name servers of Route53 zone"
+  value       = var.enable_zone ? module.amido_stacks_infra.route53_zone_name_servers : null
+}
+
+output "route53_zone_name" {
+  description = "Name of the Route53 zone"
+  value       = var.enable_zone ? module.amido_stacks_infra.route53_zone_name : null
+}

--- a/deploy/aws/stacks-eks/example/terraform.tfvars
+++ b/deploy/aws/stacks-eks/example/terraform.tfvars
@@ -45,3 +45,10 @@ map_users = [
 ########################################
 
 dns_hostedzone_name = "nonprodaws.amidostacks.com"
+
+enable_zone = true
+public_zones = {
+  "test2.amido.com" = {
+    comment = "This is a sample hosted zone don't use in production or any deployment purpose"
+  }
+}

--- a/deploy/aws/stacks-eks/example/variables.tf
+++ b/deploy/aws/stacks-eks/example/variables.tf
@@ -87,3 +87,12 @@ variable "dns_hostedzone_name" {
   description = "Name of the hosted-zone in Route53"
   type        = string
 }
+variable "enable_zone" {
+  description = "Conditionally create route53 zones"
+  type        = bool
+}
+
+variable "public_zones" {
+  type        = map(any)
+  description = "Map of Route53 zone parameters"
+}

--- a/deploy/aws/stacks-eks/main.tf
+++ b/deploy/aws/stacks-eks/main.tf
@@ -16,6 +16,11 @@ module "amido_stacks_infra" {
   cluster_endpoint_public_access  = var.cluster_endpoint_public_access
   cluster_endpoint_private_access = var.cluster_endpoint_private_access
 
+  # Route-53 Zone Configuration
+  enable_zone =  var.enable_zone
+  public_zones = var.public_zones 
+
+
   # Provides EKS API Access to Additional IAM Users and Roles, default Admin access is provided only to the cluster creator identity
   map_roles = var.map_roles
   map_users = var.map_users

--- a/deploy/aws/stacks-eks/outputs.tf
+++ b/deploy/aws/stacks-eks/outputs.tf
@@ -49,3 +49,21 @@ output "cluster_certificate_authority_data" {
   description = "base64 encoded certificate data required to communicate with your cluster"
   value       = module.amido_stacks_infra.cluster_certificate_authority_data
 }
+
+################
+# Route 53 Zones
+################
+output "route53_zone_zone_id" {
+  description = "Zone ID of Route53 zone"
+  value       = var.enable_zone ? module.amido_stacks_infra.route53_zone_zone_id : null
+}
+
+output "route53_zone_name_servers" {
+  description = "Name servers of Route53 zone"
+  value       = var.enable_zone ? module.amido_stacks_infra.route53_zone_name_servers : null
+}
+
+output "route53_zone_name" {
+  description = "Name of the Route53 zone"
+  value       = var.enable_zone ? module.amido_stacks_infra.route53_zone_name : null
+}

--- a/deploy/aws/stacks-eks/variables.tf
+++ b/deploy/aws/stacks-eks/variables.tf
@@ -81,9 +81,17 @@ variable "owner" {
   type        = string
 }
 
-
 variable "dns_hostedzone_name" {
 
   description = "Name of the hosted-zone in Route53"
   type        = string
+}
+variable "enable_zone" {
+  description = "Conditionally create route53 zones"
+  type        = bool
+}
+
+variable "public_zones" {
+  type        = map(any)
+  description = "Map of Route53 zone parameters"
 }


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Create route53 zone (this is the root module)

<!--
If you have access, to link to the Azure Devops Ticket type `AB#{ID}` in this PR or commit message,
e.g. Implements `AB#1228 - Link tickets to GitHub`
-->

#### 🤔 Why


Zone was earlier created with the cqrs / cqrs-app deployment which was creating confusing to have multiple zones for each project.

Now zones will be created as a part of core-infra deployment eg: (nonprodaws.amidostacks.com), this enables automatic record creation by external dns-controller.

#### 🛠 How

Add zone module as part of infrastructure modules

#### 👀 Evidence


#### 🕵️ How to test

terraform init --backend-config=backend.config
terraform plan && terraform apply

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
