### PR TITLE
feat(eks-iam): add eks-admin role to the cluster

### DIFF
--- a/deploy/aws/stacks-eks/example/terraform.tfvars
+++ b/deploy/aws/stacks-eks/example/terraform.tfvars
@@ -34,16 +34,17 @@ map_users = [
     groups   = ["system:masters"]
   },
   {
-    userarn  = "arn:aws:iam::316154162729:user/darren.smallwood@amido.com"
-    username = "darren.smallwood@amido.com"
-    groups   = ["system:masters"]
-  },
-  {
     userarn  = "arn:aws:iam::316154162729:user/terraform"
     username = "terraform"
     groups   = ["system:masters"]
   }
 ]
+map_roles = [{
+  groups   = ["system:masters"]
+  rolearn  = "arn:aws:iam::316154162729:role/eks-admin-role"
+  username = "eks-admin-role"
+}]
+
 
 ########################################
 # DNS Configuration


### PR DESCRIPTION
<!--
Please use the Conventional Commits specification as PR Name/Title and for all commits

[Conventional Commits](https://www.conventionalcommits.org)

Example
```
<type>: <description> <optional: - work item number>

feat: repo base files
feat: repo base files - 949
```
-->

#### 📲 What

Added IAM Role to the cluster which can be assumed by any onboarded IAM user which has permission to assume the same role.

<!--
If you have access, to link to the Azure Devops Ticket type `AB#{ID}` in this PR or commit message,
e.g. Implements `AB#1228 - Link tickets to GitHub`
-->

#### 🤔 Why

By implementing this we will not need to give permission to individual user created in AWS account, they can assume the same role to get access to the cluster.

**N.B: Better approach would have been access to IAM group which right now can't be configured due to feature limitations from aws side.**

#### 🛠 How

Using terraform and aws IAM Role

#### 👀 Evidence
<img width="1075" alt="image" src="https://user-images.githubusercontent.com/65091252/171003486-46d810fc-eda2-471f-b525-b49698a33cb4.png">



#### 🕵️ How to test

Set up your aws config file like below:
<img width="736" alt="image" src="https://user-images.githubusercontent.com/65091252/171002661-c3e0d61f-16c3-4d52-b0d7-a48582cd651d.png">

And then assume the role from cli either using granted tool or normal aws cli operations

https://aws.amazon.com/premiumsupport/knowledge-center/iam-assume-role-cli/

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
